### PR TITLE
Support building with `stack build`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /dist/
 /dist-newstyle/
 .ghc.environment.*
+/stack.yaml.lock

--- a/src/IndexShaSum.hs
+++ b/src/IndexShaSum.hs
@@ -35,14 +35,15 @@ import           Data.Semigroup         ((<>))
 #if MIN_VERSION_aeson(2,0,0)
 import qualified Data.Aeson.Key         as Key
 import qualified Data.Aeson.KeyMap      as KeyMap
+type Key = J.Key
 
-keyToText :: J.Key -> Text
+keyToText :: Key -> Text
 keyToText = Key.toText
 #else
 import qualified Data.HashMap.Strict    as KeyMap
 type Key = Text
 
-keyToText :: J.Key -> Text
+keyToText :: Key -> Text
 keyToText = id
 #endif
 
@@ -139,7 +140,7 @@ decodePkgJsonFile bs = do
         go2 m = forM (KeyMap.toList m) $ \(k,v) -> do
             J.withObject ".targets{}" (go3 k) v
 
-        go3 :: J.Key -> J.Object -> J.Parser (ByteString, ByteString)
+        go3 :: Key -> J.Object -> J.Parser (ByteString, ByteString)
         go3 k o = do
             hashes <- o J..: "hashes"
             sh256 <- hashes J..: "sha256"

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,9 @@
+resolver: lts-14.27
+
+packages:
+- .
+
+extra-deps:
+- http-io-streams-0.1.2.0
+- brotli-streams-0.0.0.0
+- brotli-0.0.0.0


### PR DESCRIPTION
Here's a pull request for a `stack.yaml` file to support `stack build` with resolver `lts-14.27` (latest LTS in the GHC 8.6.x branch).  It requires a patch to `IndexShaSum.hs` as well, since the code to support `aeson` versions <2.0.0 appears to be broken there. 