### PR TITLE
CI using Stack also on macOS and Windows (for GHC 8.6)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Andreas Abel, 2022-02-15
+# Treat golden values as binary to avoid CRLF issues under Windows
+/fixtures/*.diff        -text

--- a/.github/workflows/stack.yml
+++ b/.github/workflows/stack.yml
@@ -3,21 +3,39 @@ on: [push, pull_request]
 
 jobs:
   check:
-    runs-on: ubuntu-18.04
+    runs-on: ${{ matrix.os }}
     strategy:
-      matrix:
-        ghc-ver: [8.6.5, 8.4.4, 8.2.2]
       fail-fast: false
+      matrix:
+        os:      [ubuntu-latest]
+        ghc-ver: [8.6.5, 8.4.4, 8.2.2]
+        include:
+          - os: macos-latest
+            ghc-ver: 8.6.5
+          - os: windows-latest
+            ghc-ver: 8.6.5
     env:
       ARGS: "--stack-yaml stack-${{ matrix.ghc-ver }}.yaml --no-terminal --system-ghc"
 
     steps:
     - uses: actions/checkout@v2
+
     - uses: haskell/actions/setup@v1
       id: haskell-setup
       with:
         ghc-version: ${{ matrix.ghc-ver }}
         enable-stack: true
+
+    - name: Install the brotli library (Windows)
+      if: ${{ runner.os == 'Windows' }}
+        # Andreas Abel, 2022-02-15:
+        # Stack is packing an old version of MSYS2.
+        # To work around certification problems, we need to update msys2-keyring.
+      run: |
+        stack exec ${ARGS} -- pacman --noconfirm -Sy msys2-keyring
+        stack exec ${ARGS} -- pacman --noconfirm -S mingw-w64-x86_64-pkg-config
+        stack exec ${ARGS} -- pacman --noconfirm -S mingw-w64-x86_64-brotli
+        stack exec ${ARGS} -- pacman --noconfirm -S mingw-w64-x86_64-openssl
 
     - name: Install the brotli library (Ubuntu)
       if: ${{ runner.os == 'Linux' }}

--- a/stack-8.6.5.yaml
+++ b/stack-8.6.5.yaml
@@ -4,7 +4,18 @@ compiler: ghc-8.6.5
 packages:
 - .
 
+# Force use of newer HsOpenSSL, used by http-iostreams
+drop-packages:
+- HsOpenSSL
+
 extra-deps:
-- http-io-streams-0.1.2.0
-- brotli-streams-0.0.0.0
+  # HSOpenSSL-0.11.6.1: Windows: Use libcrypto instead of eay; allow pkg-config.
+- HsOpenSSL-0.11.6.1
+  # Needed because of drop-packages:
+- base64-bytestring-1.1.0.0
+- ghc-byteorder-4.11.0.0.10
+- xor-0.0.1.0
+  # Missing from lts-14.27:
 - brotli-0.0.0.0
+- brotli-streams-0.0.0.0
+- http-io-streams-0.1.6.0


### PR DESCRIPTION
While macOS worked out of the box, Windows was (as usual) a tedious battle:
- Install MSYS2 packages for `pkg-config`, `brotli` and `openssl` through `stack`.
- Require `HsOpenSSL-0.11.6.1` which depends on the correct C libraries (older versions look in wain for `eay32`).
- Cater for line endings of golden values via `.gitattributes` for the `fixtures/`.