### PR TITLE
Compile with Cabal-3.0 and GHC 8.8

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.13.20211116
+# version: 0.14.1
 #
-# REGENDATA ("0.13.20211116",["github","hackage-cli.cabal"])
+# REGENDATA ("0.14.1",["github","hackage-cli.cabal"])
 #
 name: Haskell-CI
 on:
@@ -28,6 +28,11 @@ jobs:
     strategy:
       matrix:
         include:
+          - compiler: ghc-8.8.4
+            compilerKind: ghc
+            compilerVersion: 8.8.4
+            setup-method: hvr-ppa
+            allow-failure: false
           - compiler: ghc-8.6.5
             compilerKind: ghc
             compilerVersion: 8.6.5

--- a/.github/workflows/stack.yml
+++ b/.github/workflows/stack.yml
@@ -8,12 +8,12 @@ jobs:
       fail-fast: false
       matrix:
         os:      [ubuntu-latest]
-        ghc-ver: [8.6.5, 8.4.4, 8.2.2]
+        ghc-ver: [8.8.4, 8.6.5, 8.4.4, 8.2.2]
         include:
           - os: macos-latest
-            ghc-ver: 8.6.5
+            ghc-ver: 8.8.4
           - os: windows-latest
-            ghc-ver: 8.6.5
+            ghc-ver: 8.8.4
     env:
       ARGS: "--stack-yaml stack-${{ matrix.ghc-ver }}.yaml --no-terminal --system-ghc"
 

--- a/hackage-cli.cabal
+++ b/hackage-cli.cabal
@@ -38,7 +38,7 @@ library cabal-revisions
   build-depends:
     , base         >= 4.10.0.0 && < 4.14
     , bytestring   >= 0.10.4.0 && < 0.12
-    , Cabal       ^>= 3.0.2.0
+    , Cabal       ^>= 3.0.1.0
     , containers   >= 0.5.0.0  && < 0.7
     , mtl          >= 2.2.2    && < 2.4
     , pretty      ^>= 1.1.2

--- a/hackage-cli.cabal
+++ b/hackage-cli.cabal
@@ -98,7 +98,9 @@ executable hackage-cli
     , filepath              ^>= 1.4.0.0
     , http-io-streams       ^>= 0.1.0.0
     , io-streams            ^>= 1.5.0.1
-    , lens                   >= 4.17    && < 5.2
+    , microlens              >= 0.4.8.3  && < 4.13
+    , microlens-mtl          >= 0.1.11.1 && < 0.3
+    , microlens-th           >= 0.4.1.3  && < 0.5
     , netrc                 ^>= 0.2.0.0
     , optparse-applicative   >= 0.14    && < 0.17
     , process-extras        ^>= 0.7.4

--- a/hackage-cli.cabal
+++ b/hackage-cli.cabal
@@ -16,6 +16,7 @@ build-type:          Simple
 
 tested-with:
   -- Keep in descending order.
+  GHC == 8.8.4
   GHC == 8.6.5
   GHC == 8.4.4
   GHC == 8.2.2
@@ -35,9 +36,9 @@ library cabal-revisions
   ghc-options:         -Wall -Wcompat
 
   build-depends:
-    , base         >= 4.10.0.0 && < 4.13
+    , base         >= 4.10.0.0 && < 4.14
     , bytestring   >= 0.10.4.0 && < 0.12
-    , Cabal       ^>= 2.4.1.0
+    , Cabal       ^>= 3.0.2.0
     , containers   >= 0.5.0.0  && < 0.7
     , mtl          >= 2.2.2    && < 2.4
     , pretty      ^>= 1.1.2

--- a/lib/Distribution/Server/Util/CabalRevisions.hs
+++ b/lib/Distribution/Server/Util/CabalRevisions.hs
@@ -1,5 +1,8 @@
+{-# LANGUAGE CPP                        #-}
 {-# LANGUAGE FlexibleContexts           #-}
+{-# LANGUAGE FunctionalDependencies     #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE OverloadedStrings          #-}
 {-# LANGUAGE ScopedTypeVariables        #-}
 {-# LANGUAGE TypeFamilies               #-}
 
@@ -21,27 +24,29 @@ module Distribution.Server.Util.CabalRevisions
     ) where
 
 -- NB: This module avoids to import any hackage-server modules
+import Distribution.CabalSpecVersion (cabalSpecLatest)
 import Distribution.Types.Dependency
 import Distribution.Types.ExeDependency
 import Distribution.Types.PkgconfigDependency
+import Distribution.Types.PkgconfigVersionRange
 import Distribution.Types.LegacyExeDependency
 import Distribution.Types.UnqualComponentName
 import Distribution.Types.CondTree
 import Distribution.Types.ForeignLib
 import Distribution.Package
-import Distribution.Text (display)
+import Distribution.Pretty (Pretty (..), prettyShow)
 import Distribution.Version
 import Distribution.Compiler (CompilerFlavor)
 import Distribution.FieldGrammar (prettyFieldGrammar)
+import Distribution.Fields.Pretty (PrettyField (..), showFields)
 import Distribution.PackageDescription
 import Distribution.PackageDescription.Parsec (parseGenericPackageDescription, runParseResult)
 import Distribution.PackageDescription.FieldGrammar (sourceRepoFieldGrammar)
 import Distribution.PackageDescription.Check
-import Distribution.Parsec.Common (showPWarning, showPError, PWarning (..))
-import Distribution.Text (Text(..))
+import Distribution.Parsec (showPWarning, showPError, PWarning (..))
 import Distribution.Simple.LocalBuildInfo (showComponentName)
 import Text.PrettyPrint as Doc
-         (nest, (<+>), colon, text, ($+$), Doc, hsep, punctuate)
+         ((<+>), colon, text, Doc, hsep, punctuate)
 
 import Control.Applicative
 import Control.Monad
@@ -57,8 +62,9 @@ import qualified Data.Semigroup as S
 import qualified Data.Monoid as M
 import qualified Data.Set as Set
 import qualified Data.Map.Strict as Map
-import Data.Foldable (foldMap)
 import Data.Proxy (Proxy(Proxy))
+
+import qualified Control.Monad.Fail as Fail
 
 -- | Entry point to cabal revision validator
 --
@@ -94,6 +100,12 @@ changeSeverity (Change s _ _ _) = s
 instance Monad CheckM where
   return         = Control.Applicative.pure
   CheckM m >>= f = CheckM (m >>= unCheckM . f)
+
+#if !MIN_VERSION_base(4,13,0)
+  fail = Fail.fail
+#endif
+
+instance Fail.MonadFail CheckM where
   fail           = CheckM . throwError
 
 -- | If we have only 'Trivial' changes, then there is no point to make
@@ -129,7 +141,7 @@ checkCabalFileRevision checkXRevision old new = do
     (pkg', warns') <- parseCabalFile new
 
     let pkgid    = packageId pkg
-        filename = display pkgid ++ ".cabal"
+        filename = prettyShow pkgid ++ ".cabal"
 
     checkGenericPackageDescription checkXRevision pkg pkg'
     checkParserWarnings filename warns warns'
@@ -177,13 +189,13 @@ checkGenericPackageDescription checkXRevision
 
     checkMaybe "Cannot add or remove library sections"
       (checkCondTree checkLibrary)
-      (withComponentName' CLibName <$> libsA)
-      (withComponentName' CLibName <$> libsB)
+      (withComponentName' (CLibName LMainLibName) <$> libsA)
+      (withComponentName' (CLibName LMainLibName) <$> libsB)
 
     checkListAssoc "Cannot add or remove sub-library sections"
       (checkCondTree checkLibrary)
-      (withComponentName CSubLibName <$> sublibsA)
-      (withComponentName CSubLibName <$> sublibsB)
+      (withComponentName (CLibName . LSubLibName) <$> sublibsA)
+      (withComponentName (CLibName . LSubLibName) <$> sublibsB)
 
     checkListAssoc "Cannot add or remove foreign-library sections"
       (checkCondTree checkForeignLib)
@@ -238,7 +250,7 @@ checkFlag flagOld flagNew = do
               (\b -> if b then "manual" else "automatic")
               (flagManual flagOld) (flagManual flagNew)
 
-    changesOk ("default of flag '" ++ fname ++ "'") display
+    changesOk ("default of flag '" ++ fname ++ "'") prettyShow
               (flagDefault flagOld) (flagDefault flagNew)
 
     changesOk ("description of flag '" ++ fname ++ "'") id
@@ -327,7 +339,7 @@ checkPackageDescriptions checkXRevision
   checkSame "The package-url field is unused, don't bother changing it."
             pkgUrlA pkgUrlB
   changesOk "bug-reports" id bugReportsA bugReportsB
-  changesOkList changesOk "source-repository" (show . ppSourceRepo)
+  changesOkList changesOk "source-repository" (showFields (const []) . (:[]) . ppSourceRepo)
             sourceReposA sourceReposB
   changesOk "synopsis"    id synopsisA synopsisB
   changesOk "description" id descriptionA descriptionB
@@ -357,7 +369,7 @@ checkSpecVersionRaw :: Check PackageDescription
 checkSpecVersionRaw pdA pdB
   | specVersionA `withinRange` range110To120
   , specVersionB `withinRange` range110To120
-  = changesOk "cabal-version" display specVersionA specVersionB
+  = changesOk "cabal-version" prettyShow specVersionA specVersionB
 
   | otherwise
   = checkSame "Cannot change the Cabal spec version"
@@ -414,7 +426,7 @@ checkCondTree checkElem (componentName, condNodeA)
       checkMaybe "Cannot add or remove the 'else' part in conditionals"
                  checkCondNode thenPartA thenPartB
 
-checkDependencies :: forall d. (Text d, IsDependency d) => ComponentName -> Check [d]
+checkDependencies :: forall d vr. (Pretty d, IsDependency vr d) => ComponentName -> Check [d]
 checkDependencies componentName ds1 ds2 = do
     forM_ removed $ \dep -> do
         fail (unwords [ "Cannot remove existing", depKind, "on"
@@ -423,7 +435,7 @@ checkDependencies componentName ds1 ds2 = do
     forM_ added $ \dep ->
         if depInAddWhitelist dep
            then logChange (Change Normal (unwords ["added the", cnameStr, "component's"
-                                                  , depKind, "on"]) "" (display dep))
+                                                  , depKind, "on"]) "" (prettyShow dep))
            else fail (unwords [ "Cannot add new", depKind, "on"
                               , depKeyShow dproxy (depKey dep)
                               , "in", cnameStr, "component"])
@@ -431,7 +443,7 @@ checkDependencies componentName ds1 ds2 = do
     forM_ changed $ \(depk, (verA, verB)) -> do
         changesOk (unwords ["the", cnameStr, "component's", depKind, "on"
                            , depKeyShow dproxy depk])
-                   display verA verB
+                   prettyShow verA verB
   where
     (removed, changed, added) = computeCanonDepChange ds1 ds2
 
@@ -442,28 +454,30 @@ checkDependencies componentName ds1 ds2 = do
 
     depKind = depTypeName dproxy ++ " dependency"
 
-class (Ord (DepKey d)) => IsDependency d where
+class (Ord (DepKey d), Pretty vr, Eq vr) => IsDependency vr d | d -> vr where
     type DepKey d
 
     depTypeName    :: Proxy d -> String
     depKey         :: d -> DepKey d
     depKeyShow     :: Proxy d -> DepKey d -> String
-    depVerRg       :: d -> VersionRange
-    reconstructDep :: DepKey d -> VersionRange -> d
+    depVerRg       :: d -> vr 
+    reconstructDep :: DepKey d -> vr -> d
 
     depInAddWhitelist :: d -> Bool
     depInAddWhitelist _ = False
 
-instance IsDependency Dependency where
+    intersectVr :: Proxy d -> vr -> vr -> vr
+
+instance IsDependency VersionRange Dependency where
     type DepKey Dependency = PackageName
 
     depTypeName Proxy             = "library"
-    depKey (Dependency pkgname _) = pkgname
-    depKeyShow Proxy              = display''
-    depVerRg (Dependency _ vr)    = vr
-    reconstructDep                = Dependency
+    depKey (Dependency pkgname _ _) = pkgname
+    depKeyShow Proxy              = prettyShow''
+    depVerRg (Dependency _ vr _)  = vr
+    reconstructDep                = \n vr -> Dependency n vr Set.empty
 
-    depInAddWhitelist (Dependency pn _) = pn `elem`
+    depInAddWhitelist (Dependency pn _ _) = pn `elem`
     -- Special case: there are some pretty weird broken packages out there, see
     --   https://github.com/haskell/hackage-server/issues/303
     -- which need us to add a new dep on `base`
@@ -482,17 +496,21 @@ instance IsDependency Dependency where
             , mkPackageName "base-orphans"
             ]
 
+    intersectVr _ = intersectVersionRanges
 
-instance IsDependency ExeDependency where
+
+instance IsDependency VersionRange ExeDependency where
     type DepKey ExeDependency = (PackageName,UnqualComponentName)
 
     depTypeName Proxy                   = "tool"
     depKey (ExeDependency pkgname cn _) = (pkgname,cn)
-    depKeyShow Proxy (pkgname,cn)       = concat ["'", display pkgname, ":", display cn, "'"]
+    depKeyShow Proxy (pkgname,cn)       = concat ["'", prettyShow pkgname, ":", prettyShow cn, "'"]
     depVerRg (ExeDependency _ _ vr)     = vr
     reconstructDep (pkgname,cn)         = ExeDependency pkgname cn
 
-instance IsDependency LegacyExeDependency where
+    intersectVr _ = intersectVersionRanges
+
+instance IsDependency VersionRange LegacyExeDependency where
     type DepKey LegacyExeDependency = String
 
     depTypeName Proxy                      = "legacy-tool"
@@ -500,6 +518,8 @@ instance IsDependency LegacyExeDependency where
     depKeyShow Proxy tname                 = "'" ++ tname ++ "'"
     depVerRg (LegacyExeDependency _ vr)    = vr
     reconstructDep                         = LegacyExeDependency
+
+    intersectVr _ = intersectVersionRanges
 
     depInAddWhitelist (LegacyExeDependency pn _) = pn `elem`
     -- list of trusted tools cabal supports w/o explicit build-tools
@@ -513,20 +533,22 @@ instance IsDependency LegacyExeDependency where
             , "hsc2hs"
             ]
 
-instance IsDependency PkgconfigDependency where
+instance IsDependency PkgconfigVersionRange PkgconfigDependency where
     type DepKey PkgconfigDependency = PkgconfigName
 
     depTypeName Proxy                      = "pkg-config"
     depKey (PkgconfigDependency pkgname _) = pkgname
-    depKeyShow Proxy                       = display''
+    depKeyShow Proxy                       = prettyShow''
     depVerRg (PkgconfigDependency _ vr)    = vr
     reconstructDep                         = PkgconfigDependency
+
+    intersectVr _ = PcIntersectVersionRanges
 
 
 -- The result tuple represents the 3 canonicalised dependency
 -- (removed deps (old ranges), retained deps (old & new ranges), added deps (new ranges))
 -- or expressed as set-operations: (A \ B, (A ∩ B), B \ A)
-computeCanonDepChange :: IsDependency d => [d] -> [d] -> ([d],[(DepKey d,(VersionRange,VersionRange))],[d])
+computeCanonDepChange :: forall vr d. IsDependency vr d => [d] -> [d] -> ([d],[(DepKey d,(vr,vr))],[d])
 computeCanonDepChange depsA depsB
     = ( mapToDeps (a `Map.difference` b)
       , Map.toList $ Map.intersectionWith (,) a b
@@ -537,7 +559,7 @@ computeCanonDepChange depsA depsB
     b = depsToMapWithCanonVerRange depsB
 
     depsToMapWithCanonVerRange
-        = Map.fromListWith (flip intersectVersionRanges) .
+        = Map.fromListWith (flip $ intersectVr (Proxy :: Proxy d)) .
           map (\d -> (depKey d, depVerRg d))
 
     mapToDeps
@@ -552,17 +574,17 @@ checkSetupBuildInfo (Just _) Nothing =
 checkSetupBuildInfo Nothing (Just (SetupBuildInfo setupDependsA _internalA)) =
     logChange $ Change Normal
                        ("added a 'custom-setup' section with 'setup-depends'")
-                       "[implicit]" (intercalate ", " (map display setupDependsA))
+                       "[implicit]" (intercalate ", " (map prettyShow setupDependsA))
 
 checkSetupBuildInfo (Just (SetupBuildInfo setupDependsA _internalA))
                     (Just (SetupBuildInfo setupDependsB _internalB)) = do
     forM_ removed $ \dep ->
-      logChange $ Change Normal ("removed 'custom-setup' dependency on") (display dep) ""
+      logChange $ Change Normal ("removed 'custom-setup' dependency on") (prettyShow dep) ""
     forM_ added $ \dep ->
-      logChange $ Change Normal ("added 'custom-setup' dependency on") "" (display dep)
+      logChange $ Change Normal ("added 'custom-setup' dependency on") "" (prettyShow dep)
     forM_ changed $ \(pkgn, (verA, verB)) ->
-        changesOk ("the 'custom-setup' dependency on " ++ display'' pkgn)
-                  display verA verB
+        changesOk ("the 'custom-setup' dependency on " ++ prettyShow'' pkgn)
+                  prettyShow verA verB
   where
     (removed, changed, added) =
       computeCanonDepChange setupDependsA setupDependsB
@@ -570,14 +592,15 @@ checkSetupBuildInfo (Just (SetupBuildInfo setupDependsA _internalA))
 checkLibrary :: ComponentName -> Check Library
 checkLibrary componentName
              (Library modulesA reexportedA requiredSigsA exposedSigsA
-                      exposedA buildInfoA)
+                      exposedA visibilityA buildInfoA)
              (Library modulesB reexportedB requiredSigsB exposedSigsB
-                      exposedB buildInfoB) = do
+                      exposedB visibilityB buildInfoB) = do
   checkSame "Cannot change the exposed modules" modulesA modulesB
   checkSame "Cannot change the re-exported modules" reexportedA reexportedB
   checkSame "Cannot change the required signatures" requiredSigsA requiredSigsB
   checkSame "Cannot change the exposed signatures"  exposedSigsA  exposedSigsB
   checkSame "Cannot change the package exposed status" exposedA exposedB
+  checkSame "Cannot change the package visibility" visibilityA visibilityB
   checkBuildInfo componentName buildInfoA buildInfoB
 
 checkForeignLib :: ComponentName -> Check ForeignLib
@@ -618,11 +641,11 @@ checkBuildInfo :: ComponentName -> Check BuildInfo
 checkBuildInfo componentName biA biB = do
     -- @other-extension@
     changesOkSet ("'other-extensions' in " ++ showComponentName componentName ++ " component")
-              display
+              prettyShow
               (Set.fromList $ otherExtensions biA) (Set.fromList $ otherExtensions biB)
 
     -- @buildable@
-    changesOk ("'buildable' in " ++ showComponentName componentName ++ " component") display
+    changesOk ("'buildable' in " ++ showComponentName componentName ++ " component") prettyShow
               (buildable biA) (buildable biB)
 
     -- @build-tool-depends@
@@ -640,8 +663,7 @@ checkBuildInfo componentName biA biB = do
         (pkgconfigDepends biA)
         (pkgconfigDepends biB)
 
-    checkSame "Cannot change build information \
-              \(just the dependency version constraints)"
+    checkSame "Cannot change build information (just the dependency version constraints)"
               (biA { targetBuildDepends = [], otherExtensions = [], buildTools = [], buildToolDepends = [], pkgconfigDepends = [], buildable = True })
               (biB { targetBuildDepends = [], otherExtensions = [], buildTools = [], buildToolDepends = [], pkgconfigDepends = [], buildable = True })
 
@@ -675,9 +697,9 @@ changesOkSet what render old new = do
     renderSet = intercalate ", " . map render . Set.toList
 
 
--- | Single-quote-wrapping 'display'
-display'' :: Text a => a -> String
-display'' x = "'" ++ display x ++ "'"
+-- | Single-quote-wrapping 'prettyShow'
+prettyShow'' :: Pretty a => a -> String
+prettyShow'' x = "'" ++ prettyShow x ++ "'"
 
 checkSame :: Eq a => String -> Check a
 checkSame msg x y | x == y    = return ()
@@ -709,17 +731,13 @@ checkMaybe msg _     _        _        = fail msg
 ppTestedWith :: [(CompilerFlavor, VersionRange)] -> Doc
 ppTestedWith = hsep . punctuate colon . map (uncurry ppPair)
   where
-    ppPair compiler vr = text (display compiler) <+> text (display vr)
+    ppPair compiler vr = text (prettyShow compiler) <+> text (prettyShow vr)
 
---TODO: export from Cabal
-ppSourceRepo :: SourceRepo -> Doc
-ppSourceRepo repo = emptyLine $
-    text "source-repository" <+> disp (repoKind repo)
-    $+$
-    nest 4 (prettyFieldGrammar (sourceRepoFieldGrammar (repoKind repo)) repo)
+ppSourceRepo :: SourceRepo -> PrettyField ()
+ppSourceRepo repo = PrettySection () "source-repository" [pretty kind] $
+    prettyFieldGrammar cabalSpecLatest (sourceRepoFieldGrammar kind) repo
   where
-    emptyLine :: Doc -> Doc
-    emptyLine d = text " " $+$ d
+    kind = repoKind repo
 
 -- TODO: Verify that we don't need to worry about UTF8
 -- | Insert or update \"x-revision:\" field

--- a/src/CabalEdit.hs
+++ b/src/CabalEdit.hs
@@ -15,9 +15,9 @@ import qualified Data.ByteString.Char8                  as BS8
 #if !MIN_VERSION_base(4,11,0)
 import           Data.Semigroup                         ((<>))
 #endif
-import qualified Distribution.Parsec.Common             as C
-import qualified Distribution.Parsec.Field              as C
-import qualified Distribution.Parsec.Parser             as C
+import qualified Distribution.Fields.Field              as C
+import qualified Distribution.Fields.Parser             as C
+import qualified Distribution.Parsec.Position           as C (Position(Position))
 
 type PkgRev  = Word
 

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -18,7 +18,6 @@ import qualified Data.Aeson.Types                     as J
 import qualified Data.ByteString.Builder              as Builder
 import           Control.DeepSeq
 import           Control.Exception
-import           Control.Lens
 import           Control.Monad
 import           Control.Monad.State.Strict
 import           Data.Bits
@@ -45,6 +44,11 @@ import qualified Distribution.Pretty                    as C
 import qualified Distribution.Verbosity                 as C
 import qualified Distribution.Version                   as C
 import qualified Distribution.Text                      as C
+
+import           Lens.Micro
+import           Lens.Micro.Mtl
+import           Lens.Micro.TH
+
 import           Network.Http.Client
 import           Network.NetRc
 import           Numeric.Natural                        (Natural)
@@ -94,7 +98,7 @@ data HConn = HConn
 makeLenses ''HConn
 
 -- | Requests that can be issued in current connection before exhausting the 50-req/conn server limit
-hcReqLeft :: Getter HConn Natural -- (Natural -> f Natural) -> HConn -> f HConn
+hcReqLeft :: SimpleGetter HConn Natural -- (Natural -> f Natural) -> HConn -> f HConn
 hcReqLeft = hcReqCnt . to f
   where
     f n | n > lim   = 0

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -38,10 +38,9 @@ import           Data.Semigroup                         (Semigroup(..))
 import qualified Distribution.Package                   as C
 import qualified Distribution.PackageDescription        as C
 import qualified Distribution.PackageDescription.Parsec as C
-import qualified Distribution.Parsec.Class              as C
-import qualified Distribution.Parsec.Common             as C
-import qualified Distribution.Parsec.Field              as C
-import qualified Distribution.Parsec.Parser             as C
+import qualified Distribution.Parsec                    as C
+import qualified Distribution.Fields                    as C
+import qualified Distribution.Fields.Field              as C (fieldAnn)
 import qualified Distribution.Pretty                    as C
 import qualified Distribution.Verbosity                 as C
 import qualified Distribution.Version                   as C
@@ -914,7 +913,7 @@ mainWithOptions Options {..} = do
         (v:vs) -> List.foldl' C.intersectVersionRanges v vs
       where
         vss = gpd ^.. LC.condLibrary . _Just . condTreeDataL . LC.targetBuildDepends . traverse . to ext . _Just
-        ext (C.Dependency pkgName' vr)
+        ext (C.Dependency pkgName' vr _)
            | pkgName == pkgName' = Just vr
            | otherwise           = Nothing
 

--- a/stack-8.2.2.yaml
+++ b/stack-8.2.2.yaml
@@ -6,9 +6,7 @@ packages:
 
 extra-deps:
 - Cabal-2.4.1.0
-- cabal-doctest-1.0.7
 - brotli-streams-0.0.0.0
 - brotli-0.0.0.0
 - http-io-streams-0.1.2.0
-- lens-4.17
 - netrc-0.2.0.0

--- a/stack-8.2.2.yaml
+++ b/stack-8.2.2.yaml
@@ -5,7 +5,7 @@ packages:
 - .
 
 extra-deps:
-- Cabal-2.4.1.0
+- Cabal-3.0.2.0
 - brotli-streams-0.0.0.0
 - brotli-0.0.0.0
 - http-io-streams-0.1.2.0

--- a/stack-8.4.4.yaml
+++ b/stack-8.4.4.yaml
@@ -9,5 +9,4 @@ extra-deps:
 - brotli-streams-0.0.0.0
 - brotli-0.0.0.0
 - http-io-streams-0.1.2.0
-- lens-4.17
 - netrc-0.2.0.0

--- a/stack-8.4.4.yaml
+++ b/stack-8.4.4.yaml
@@ -5,7 +5,7 @@ packages:
 - .
 
 extra-deps:
-- Cabal-2.4.1.0
+- Cabal-3.0.2.0
 - brotli-streams-0.0.0.0
 - brotli-0.0.0.0
 - http-io-streams-0.1.2.0

--- a/stack-8.8.4.yaml
+++ b/stack-8.8.4.yaml
@@ -1,5 +1,5 @@
-resolver: lts-14.27
-compiler: ghc-8.6.5
+resolver: lts-16.31
+compiler: ghc-8.8.4
 
 packages:
 - .
@@ -15,8 +15,7 @@ extra-deps:
 - base64-bytestring-1.1.0.0
 - ghc-byteorder-4.11.0.0.10
 - xor-0.0.1.0
-  # Missing from lts-14.27:
-- Cabal-3.0.2.0
+  # Missing from lts-16.31
 - brotli-0.0.0.0
 - brotli-streams-0.0.0.0
 - http-io-streams-0.1.6.0

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,1 +1,1 @@
-stack-8.6.5.yaml
+stack-8.8.4.yaml


### PR DESCRIPTION
Extends PR #13.

- switch to `Cabal-3.0.1`
- pull changes to `Distribution.Server.Util.CabalRevisions` from `hackage-server` (ack @phadej)
- get rid of `lens`, just use `microlens` (less dependencies)
- update snapshot configurations for stack
- update CI