### PR TITLE
Cabal 3.2 and GHC 8.10

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -28,6 +28,11 @@ jobs:
     strategy:
       matrix:
         include:
+          - compiler: ghc-8.10.7
+            compilerKind: ghc
+            compilerVersion: 8.10.7
+            setup-method: ghcup
+            allow-failure: false
           - compiler: ghc-8.8.4
             compilerKind: ghc
             compilerVersion: 8.8.4
@@ -54,13 +59,23 @@ jobs:
         run: |
           apt-get update
           apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5
-          apt-add-repository -y 'ppa:hvr/ghc'
-          apt-get update
-          apt-get install -y "$HCNAME"
-          mkdir -p "$HOME/.ghcup/bin"
-          curl -sL https://downloads.haskell.org/ghcup/0.1.17.3/x86_64-linux-ghcup-0.1.17.3 > "$HOME/.ghcup/bin/ghcup"
-          chmod a+x "$HOME/.ghcup/bin/ghcup"
-          "$HOME/.ghcup/bin/ghcup" install cabal 3.6.2.0
+          if [ "${{ matrix.setup-method }}" = ghcup ]; then
+            mkdir -p "$HOME/.ghcup/bin"
+            curl -sL https://downloads.haskell.org/ghcup/0.1.17.3/x86_64-linux-ghcup-0.1.17.3 > "$HOME/.ghcup/bin/ghcup"
+            chmod a+x "$HOME/.ghcup/bin/ghcup"
+            "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER"
+            "$HOME/.ghcup/bin/ghcup" install cabal 3.6.2.0
+            apt-get update
+            apt-get install -y libbrotli-dev
+          else
+            apt-add-repository -y 'ppa:hvr/ghc'
+            apt-get update
+            apt-get install -y "$HCNAME" libbrotli-dev
+            mkdir -p "$HOME/.ghcup/bin"
+            curl -sL https://downloads.haskell.org/ghcup/0.1.17.3/x86_64-linux-ghcup-0.1.17.3 > "$HOME/.ghcup/bin/ghcup"
+            chmod a+x "$HOME/.ghcup/bin/ghcup"
+            "$HOME/.ghcup/bin/ghcup" install cabal 3.6.2.0
+          fi
         env:
           HCKIND: ${{ matrix.compilerKind }}
           HCNAME: ${{ matrix.compiler }}
@@ -72,11 +87,20 @@ jobs:
           echo "CABAL_DIR=$HOME/.cabal" >> "$GITHUB_ENV"
           echo "CABAL_CONFIG=$HOME/.cabal/config" >> "$GITHUB_ENV"
           HCDIR=/opt/$HCKIND/$HCVER
-          HC=$HCDIR/bin/$HCKIND
-          echo "HC=$HC" >> "$GITHUB_ENV"
-          echo "HCPKG=$HCDIR/bin/$HCKIND-pkg" >> "$GITHUB_ENV"
-          echo "HADDOCK=$HCDIR/bin/haddock" >> "$GITHUB_ENV"
-          echo "CABAL=$HOME/.ghcup/bin/cabal-3.6.2.0 -vnormal+nowrap" >> "$GITHUB_ENV"
+          if [ "${{ matrix.setup-method }}" = ghcup ]; then
+            HC=$HOME/.ghcup/bin/$HCKIND-$HCVER
+            echo "HC=$HC" >> "$GITHUB_ENV"
+            echo "HCPKG=$HOME/.ghcup/bin/$HCKIND-pkg-$HCVER" >> "$GITHUB_ENV"
+            echo "HADDOCK=$HOME/.ghcup/bin/haddock-$HCVER" >> "$GITHUB_ENV"
+            echo "CABAL=$HOME/.ghcup/bin/cabal-3.6.2.0 -vnormal+nowrap" >> "$GITHUB_ENV"
+          else
+            HC=$HCDIR/bin/$HCKIND
+            echo "HC=$HC" >> "$GITHUB_ENV"
+            echo "HCPKG=$HCDIR/bin/$HCKIND-pkg" >> "$GITHUB_ENV"
+            echo "HADDOCK=$HCDIR/bin/haddock" >> "$GITHUB_ENV"
+            echo "CABAL=$HOME/.ghcup/bin/cabal-3.6.2.0 -vnormal+nowrap" >> "$GITHUB_ENV"
+          fi
+
           HCNUMVER=$(${HC} --numeric-version|perl -ne '/^(\d+)\.(\d+)\.(\d+)(\.(\d+))?$/; print(10000 * $1 + 100 * $2 + ($3 == 0 ? $5 != 1 : $3))')
           echo "HCNUMVER=$HCNUMVER" >> "$GITHUB_ENV"
           echo "ARG_TESTS=--enable-tests" >> "$GITHUB_ENV"

--- a/.github/workflows/stack.yml
+++ b/.github/workflows/stack.yml
@@ -8,12 +8,12 @@ jobs:
       fail-fast: false
       matrix:
         os:      [ubuntu-latest]
-        ghc-ver: [8.8.4, 8.6.5, 8.4.4, 8.2.2]
+        ghc-ver: [8.10.7, 8.8.4, 8.6.5, 8.4.4, 8.2.2]
         include:
           - os: macos-latest
-            ghc-ver: 8.8.4
+            ghc-ver: 8.10.7
           - os: windows-latest
-            ghc-ver: 8.8.4
+            ghc-ver: 8.10.7
     env:
       ARGS: "--stack-yaml stack-${{ matrix.ghc-ver }}.yaml --no-terminal --system-ghc"
 

--- a/cabal.haskell-ci
+++ b/cabal.haskell-ci
@@ -1,3 +1,5 @@
 -- By default `installed` constraints are used for packages
 -- in global db. We can modify which constraints are used.
 installed: +all -binary -Cabal
+
+apt: libbrotli-dev

--- a/hackage-cli.cabal
+++ b/hackage-cli.cabal
@@ -16,6 +16,7 @@ build-type:          Simple
 
 tested-with:
   -- Keep in descending order.
+  GHC == 8.10.7
   GHC == 8.8.4
   GHC == 8.6.5
   GHC == 8.4.4
@@ -36,9 +37,9 @@ library cabal-revisions
   ghc-options:         -Wall -Wcompat
 
   build-depends:
-    , base         >= 4.10.0.0 && < 4.14
+    , base         >= 4.10.0.0 && < 4.15
     , bytestring   >= 0.10.4.0 && < 0.12
-    , Cabal       ^>= 3.0.1.0
+    , Cabal       ^>= 3.2.1.0
     , containers   >= 0.5.0.0  && < 0.7
     , mtl          >= 2.2.2    && < 2.4
     , pretty      ^>= 1.1.2
@@ -102,7 +103,7 @@ executable hackage-cli
     , microlens-mtl          >= 0.1.11.1 && < 0.3
     , microlens-th           >= 0.4.1.3  && < 0.5
     , netrc                 ^>= 0.2.0.0
-    , optparse-applicative   >= 0.14    && < 0.17
+    , optparse-applicative   >= 0.14    && < 0.18
     , process-extras        ^>= 0.7.4
     , semigroups             >= 0.18.3  && < 0.21
     , stringsearch          ^>= 0.3.6

--- a/lib/Distribution/Server/Util/CabalRevisions.hs
+++ b/lib/Distribution/Server/Util/CabalRevisions.hs
@@ -45,6 +45,7 @@ import Distribution.PackageDescription.FieldGrammar (sourceRepoFieldGrammar)
 import Distribution.PackageDescription.Check
 import Distribution.Parsec (showPWarning, showPError, PWarning (..))
 import Distribution.Simple.LocalBuildInfo (showComponentName)
+import Distribution.Utils.ShortText
 import Text.PrettyPrint as Doc
          ((<+>), colon, text, Doc, hsep, punctuate)
 
@@ -329,21 +330,21 @@ checkPackageDescriptions checkXRevision
             (packageVersion packageIdA) (packageVersion packageIdB)
   checkSame "Cannot change the license"
             (licenseRawA, licenseFilesA) (licenseRawB, licenseFilesB)
-  changesOk "copyright"  id copyrightA copyrightB
-  changesOk "maintainer" id maintainerA maintainerB
-  changesOk "author"     id authorA authorB
+  changesOk "copyright"  fromShortText copyrightA copyrightB
+  changesOk "maintainer" fromShortText maintainerA maintainerB
+  changesOk "author"     fromShortText authorA authorB
   checkSame "The stability field is unused, don't bother changing it."
             stabilityA stabilityB
   changesOk' Trivial "tested-with" (show . ppTestedWith) testedWithA testedWithB
-  changesOk "homepage" id homepageA homepageB
+  changesOk "homepage" fromShortText homepageA homepageB
   checkSame "The package-url field is unused, don't bother changing it."
             pkgUrlA pkgUrlB
-  changesOk "bug-reports" id bugReportsA bugReportsB
+  changesOk "bug-reports" fromShortText bugReportsA bugReportsB
   changesOkList changesOk "source-repository" (showFields (const []) . (:[]) . ppSourceRepo)
             sourceReposA sourceReposB
-  changesOk "synopsis"    id synopsisA synopsisB
-  changesOk "description" id descriptionA descriptionB
-  changesOk "category"    id categoryA categoryB
+  changesOk "synopsis"    fromShortText synopsisA synopsisB
+  changesOk "description" fromShortText descriptionA descriptionB
+  changesOk "category"    fromShortText categoryA categoryB
   checkSame "Cannot change the build-type"
             buildTypeRawA buildTypeRawB
   checkSame "Cannot change the data files"

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -27,6 +27,7 @@ import qualified Data.ByteString.Char8                  as BS8
 import qualified Data.ByteString.Lazy                   as BSL
 import qualified Data.ByteString.Search                 as BSS
 import           Data.Char                              (isSpace)
+import           Data.Foldable                          (toList)
 import qualified Data.List                              as List
 import           Data.Maybe
 import           Data.Time.Clock.POSIX                  (getPOSIXTime)
@@ -909,7 +910,7 @@ mainWithOptions Options {..} = do
 
     parseGenericPackageDescription' bs =
         case snd $ C.runParseResult $ C.parseGenericPackageDescription bs of
-            Left (_, es) -> error $ List.intercalate "\n" $ map (C.showPError "<.cabal>") es
+            Left (_, es) -> error $ List.intercalate "\n" $ map (C.showPError "<.cabal>") $ toList es
             Right x      -> x
 
     extractRange gpd pkgName = case vss of

--- a/stack-8.10.7.yaml
+++ b/stack-8.10.7.yaml
@@ -1,0 +1,14 @@
+resolver: lts-18.25
+compiler: ghc-8.10.7
+
+packages:
+- .
+
+extra-deps:
+- brotli-0.0.0.0
+- brotli-streams-0.0.0.0
+- http-io-streams-0.1.6.0@rev:0
+- netrc-0.2.0.0
+- xor-0.0.1.0
+# For http-io-streams-0.1.6.0@rev:1
+# - base64-bytestring-1.2.1.0

--- a/stack-8.2.2.yaml
+++ b/stack-8.2.2.yaml
@@ -5,7 +5,7 @@ packages:
 - .
 
 extra-deps:
-- Cabal-3.0.2.0
+- Cabal-3.2.1.0
 - brotli-streams-0.0.0.0
 - brotli-0.0.0.0
 - http-io-streams-0.1.2.0

--- a/stack-8.4.4.yaml
+++ b/stack-8.4.4.yaml
@@ -5,7 +5,7 @@ packages:
 - .
 
 extra-deps:
-- Cabal-3.0.2.0
+- Cabal-3.2.1.0
 - brotli-streams-0.0.0.0
 - brotli-0.0.0.0
 - http-io-streams-0.1.2.0

--- a/stack-8.6.5.yaml
+++ b/stack-8.6.5.yaml
@@ -16,7 +16,7 @@ extra-deps:
 - ghc-byteorder-4.11.0.0.10
 - xor-0.0.1.0
   # Missing from lts-14.27:
-- Cabal-3.0.2.0
+- Cabal-3.2.1.0
 - brotli-0.0.0.0
 - brotli-streams-0.0.0.0
-- http-io-streams-0.1.6.0
+- http-io-streams-0.1.6.0@rev:0

--- a/stack-8.8.4.yaml
+++ b/stack-8.8.4.yaml
@@ -16,6 +16,7 @@ extra-deps:
 - ghc-byteorder-4.11.0.0.10
 - xor-0.0.1.0
   # Missing from lts-16.31
+- Cabal-3.2.1.0
 - brotli-0.0.0.0
 - brotli-streams-0.0.0.0
-- http-io-streams-0.1.6.0
+- http-io-streams-0.1.6.0@rev:0

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,1 +1,1 @@
-stack-8.8.4.yaml
+stack-8.10.7.yaml


### PR DESCRIPTION
Fix #15:
- pull changes from hackage-server (CabalRevisions.hs)
- fix Main.hs
- bump Cabal to 3.2.1.0
- allow GHC 8.10
- update CI