### PR TITLE
Switch to Cabal-3.4, allow GHC 9.0

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -28,6 +28,11 @@ jobs:
     strategy:
       matrix:
         include:
+          - compiler: ghc-9.0.2
+            compilerKind: ghc
+            compilerVersion: 9.0.2
+            setup-method: ghcup
+            allow-failure: false
           - compiler: ghc-8.10.7
             compilerKind: ghc
             compilerVersion: 8.10.7

--- a/.github/workflows/stack.yml
+++ b/.github/workflows/stack.yml
@@ -8,7 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         os:      [ubuntu-latest]
-        ghc-ver: [8.10.7, 8.8.4, 8.6.5, 8.4.4, 8.2.2]
+        ghc-ver: [9.0.2, 8.10.7, 8.8.4, 8.6.5, 8.4.4, 8.2.2]
         include:
           - os: macos-latest
             ghc-ver: 8.10.7

--- a/fixtures/SVGFonts.1.2.diff
+++ b/fixtures/SVGFonts.1.2.diff
@@ -2,4 +2,4 @@ OK
 Normal
 the library component's library dependency on 'diagrams-lib'
 - <1.4
-+ -any
++ >=0

--- a/fixtures/SVGFonts.2.1.diff
+++ b/fixtures/SVGFonts.2.1.diff
@@ -1,5 +1,5 @@
 OK
 Normal
 the library component's library dependency on 'diagrams-lib'
-- -any
+- >=0
 + <1.4

--- a/hackage-cli.cabal
+++ b/hackage-cli.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.4
 name:                hackage-cli
-version:             0.0.3.2
+version:             0.0.3.4
 
 synopsis:            CLI tool for Hackage
 description:
@@ -16,6 +16,7 @@ build-type:          Simple
 
 tested-with:
   -- Keep in descending order.
+  GHC == 9.0.2
   GHC == 8.10.7
   GHC == 8.8.4
   GHC == 8.6.5
@@ -37,9 +38,9 @@ library cabal-revisions
   ghc-options:         -Wall -Wcompat
 
   build-depends:
-    , base         >= 4.10.0.0 && < 4.15
+    , base         >= 4.10.0.0 && < 4.16
     , bytestring   >= 0.10.4.0 && < 0.12
-    , Cabal       ^>= 3.2.1.0
+    , Cabal       ^>= 3.4.1.0
     , containers   >= 0.5.0.0  && < 0.7
     , mtl          >= 2.2.2    && < 2.4
     , pretty      ^>= 1.1.2

--- a/stack-8.10.7.yaml
+++ b/stack-8.10.7.yaml
@@ -1,10 +1,11 @@
-resolver: lts-18.25
+resolver: lts-18.26
 compiler: ghc-8.10.7
 
 packages:
 - .
 
 extra-deps:
+- Cabal-3.4.1.0
 - brotli-0.0.0.0
 - brotli-streams-0.0.0.0
 - http-io-streams-0.1.6.0@rev:0

--- a/stack-8.2.2.yaml
+++ b/stack-8.2.2.yaml
@@ -5,7 +5,7 @@ packages:
 - .
 
 extra-deps:
-- Cabal-3.2.1.0
+- Cabal-3.4.1.0
 - brotli-streams-0.0.0.0
 - brotli-0.0.0.0
 - http-io-streams-0.1.2.0

--- a/stack-8.4.4.yaml
+++ b/stack-8.4.4.yaml
@@ -5,7 +5,7 @@ packages:
 - .
 
 extra-deps:
-- Cabal-3.2.1.0
+- Cabal-3.4.1.0
 - brotli-streams-0.0.0.0
 - brotli-0.0.0.0
 - http-io-streams-0.1.2.0

--- a/stack-8.6.5.yaml
+++ b/stack-8.6.5.yaml
@@ -16,7 +16,7 @@ extra-deps:
 - ghc-byteorder-4.11.0.0.10
 - xor-0.0.1.0
   # Missing from lts-14.27:
-- Cabal-3.2.1.0
+- Cabal-3.4.1.0
 - brotli-0.0.0.0
 - brotli-streams-0.0.0.0
 - http-io-streams-0.1.6.0@rev:0

--- a/stack-8.8.4.yaml
+++ b/stack-8.8.4.yaml
@@ -16,7 +16,7 @@ extra-deps:
 - ghc-byteorder-4.11.0.0.10
 - xor-0.0.1.0
   # Missing from lts-16.31
-- Cabal-3.2.1.0
+- Cabal-3.4.1.0
 - brotli-0.0.0.0
 - brotli-streams-0.0.0.0
 - http-io-streams-0.1.6.0@rev:0

--- a/stack-9.0.2.yaml
+++ b/stack-9.0.2.yaml
@@ -1,0 +1,12 @@
+resolver: nightly-2022-02-19
+compiler: ghc-9.0.2
+
+packages:
+- .
+
+extra-deps:
+- brotli-0.0.0.0
+- brotli-streams-0.0.0.0
+- http-io-streams-0.1.6.0
+- netrc-0.2.0.0
+- xor-0.0.1.1


### PR DESCRIPTION
Switch to Cabal-3.4, allow GHC 9.0.

The old "-any" constraint will now be printed as ">=0".
Cabal-3.4 removed the "Any" constructor (as it is redundant) and parses "-any" as ">=0".  It did not introduce any function for legacy-printing ">=0" as "-any".