### PR TITLE
Skip errors when running add-bound on several files

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,8 +76,10 @@ We walk through a typical workflow:
      build-depends: pkg-y < 4.5.6
    ```
    to the `library` section of each of the `.cabal` files.
-   There must be exactly one `library` section, otherwise `hackage-cli` will crash
-   or produce a garbage result.
+   If files without a `library` section are encountered (as in ancient `.cabal` formats),
+   they will be skipped, but the final exitcode of `hackage-cli` will be 1 (error).
+   If a file contains more than one `library` section, `hackage-cli` will take the first
+   such section.  (This might not produce the intended result, so double-checking is advised.)
 
    If this bound does not further constrain the existing version range
    for `pkg-y`, it will not be added unless `--force` is used.

--- a/hackage-cli.cabal
+++ b/hackage-cli.cabal
@@ -70,9 +70,13 @@ test-suite cabal-revisions-tests
 
 executable hackage-cli
   default-language:    Haskell2010
+  default-extensions:
+    DeriveFunctor
+    LambdaCase
+    NamedFieldPuns
+
   other-extensions:
     CPP
-    LambdaCase
     OverloadedStrings
     RecordWildCards
     TemplateHaskell

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -446,6 +446,10 @@ nsplitAt n = splitAt i
   where
     i = fromMaybe (error "nsplitAt: overflow") $ toIntegralSized n
 
+-- | Returns the position @(line, indentation)@ where to insert the
+-- new @build-depends:@ immediately after the first @library@ section,
+-- if any.
+--
 findLibrarySection :: [C.Field C.Position] -> Maybe (Int, Int)
 findLibrarySection [] = Nothing
 findLibrarySection (C.Section (C.Name (C.Position row _) "library") [] fs : _) =

--- a/stack-9.2.2.yaml
+++ b/stack-9.2.2.yaml
@@ -1,4 +1,4 @@
-resolver: nightly-2022-05-20
+resolver: nightly-2022-05-25
 compiler: ghc-9.2.2
 compiler-check: match-exact
 


### PR DESCRIPTION
Skip errors when running `add-bound` on several files.

If `add-bound` fails for a cabal file (e.g. parse error, missing library section), just skip to the next file.

The final exitcode is 0 if `add-bound` succeeded for all files.