### PR TITLE
Support library Cabal >= 3.7

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.15.20220525
+# version: 0.15.20220609
 #
-# REGENDATA ("0.15.20220525",["github","hackage-cli.cabal"])
+# REGENDATA ("0.15.20220609",["github","hackage-cli.cabal"])
 #
 name: Haskell-CI
 on:
@@ -32,9 +32,9 @@ jobs:
     strategy:
       matrix:
         include:
-          - compiler: ghc-9.4.0.20220501
+          - compiler: ghc-9.4.0.20220523
             compilerKind: ghc
-            compilerVersion: 9.4.0.20220501
+            compilerVersion: 9.4.0.20220523
             setup-method: ghcup
             allow-failure: true
           - compiler: ghc-9.2.3
@@ -83,8 +83,8 @@ jobs:
             curl -sL https://downloads.haskell.org/ghcup/0.1.17.8/x86_64-linux-ghcup-0.1.17.8 > "$HOME/.ghcup/bin/ghcup"
             chmod a+x "$HOME/.ghcup/bin/ghcup"
             if $HEADHACKAGE; then "$HOME/.ghcup/bin/ghcup" config add-release-channel https://raw.githubusercontent.com/haskell/ghcup-metadata/master/ghcup-prereleases-0.0.7.yaml; fi
-            "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER"
-            "$HOME/.ghcup/bin/ghcup" install cabal 3.6.2.0
+            "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
+            "$HOME/.ghcup/bin/ghcup" install cabal 3.6.2.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
             apt-get update
             apt-get install -y libbrotli-dev
           else
@@ -94,7 +94,7 @@ jobs:
             mkdir -p "$HOME/.ghcup/bin"
             curl -sL https://downloads.haskell.org/ghcup/0.1.17.8/x86_64-linux-ghcup-0.1.17.8 > "$HOME/.ghcup/bin/ghcup"
             chmod a+x "$HOME/.ghcup/bin/ghcup"
-            "$HOME/.ghcup/bin/ghcup" install cabal 3.6.2.0
+            "$HOME/.ghcup/bin/ghcup" install cabal 3.6.2.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
           fi
         env:
           HCKIND: ${{ matrix.compilerKind }}
@@ -163,6 +163,7 @@ jobs:
                         26021a13b401500c8eb2761ca95c61f2d625bfef951b939a8124ed12ecf07329
                         f76d08be13e9a61a377a85e2fb63f4c5435d40f8feb3e12eb05905edb8cdea89
              key-threshold: 3
+          active-repositories: hackage.haskell.org, head.hackage.ghc.haskell.org:override
           EOF
           fi
           cat >> $CABAL_CONFIG <<EOF

--- a/hackage-cli.cabal
+++ b/hackage-cli.cabal
@@ -45,7 +45,7 @@ library cabal-revisions
   build-depends:
     , base         >= 4.10.0.0 && < 4.18
     , bytestring   >= 0.10.4.0 && < 0.12
-    , Cabal        >= 3.4      && < 3.7
+    , Cabal        >= 3.4      && < 3.10
     , containers   >= 0.5.0.0  && < 0.7
     , mtl          >= 2.2.2    && < 2.4
     , pretty      ^>= 1.1.2

--- a/lib/Distribution/Server/Util/CabalRevisions.hs
+++ b/lib/Distribution/Server/Util/CabalRevisions.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE FlexibleContexts           #-}
 {-# LANGUAGE FunctionalDependencies     #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE PatternSynonyms            #-}
 {-# LANGUAGE OverloadedStrings          #-}
 {-# LANGUAGE ScopedTypeVariables        #-}
 {-# LANGUAGE TypeFamilies               #-}
@@ -39,6 +40,9 @@ import Distribution.Version
 import Distribution.Compiler (CompilerFlavor)
 import Distribution.FieldGrammar (prettyFieldGrammar)
 import Distribution.Fields.Pretty (PrettyField (..), showFields)
+#if MIN_VERSION_Cabal(3,7,0)
+import Distribution.Fields.Pretty (pattern NoComment)
+#endif
 import Distribution.PackageDescription
 import Distribution.PackageDescription.Parsec (parseGenericPackageDescription, runParseResult)
 import Distribution.PackageDescription.FieldGrammar (sourceRepoFieldGrammar)
@@ -340,7 +344,7 @@ checkPackageDescriptions checkXRevision
   checkSame "The package-url field is unused, don't bother changing it."
             pkgUrlA pkgUrlB
   changesOk "bug-reports" fromShortText bugReportsA bugReportsB
-  changesOkList changesOk "source-repository" (showFields (const []) . (:[]) . ppSourceRepo)
+  changesOkList changesOk "source-repository" (showFields noComment . (:[]) . ppSourceRepo)
             sourceReposA sourceReposB
   changesOk "synopsis"    fromShortText synopsisA synopsisB
   changesOk "description" fromShortText descriptionA descriptionB
@@ -365,6 +369,12 @@ checkPackageDescriptions checkXRevision
 
   when checkXRevision $ checkRevision customFieldsPDA customFieldsPDB
   checkCuration customFieldsPDA customFieldsPDB
+  where
+#if MIN_VERSION_Cabal(3,7,0)
+    noComment _ = NoComment
+#else
+    noComment _ = []
+#endif
 
 checkSpecVersionRaw :: Check PackageDescription
 checkSpecVersionRaw pdA pdB
@@ -625,10 +635,20 @@ checkExecutable componentName
 
 checkTestSuite :: ComponentName -> Check TestSuite
 checkTestSuite componentName
+#if MIN_VERSION_Cabal(3,7,0)
+               (TestSuite _nameA interfaceA buildInfoA testGeneratorsA)
+               (TestSuite _nameB interfaceB buildInfoB testGeneratorsB)
+#else
                (TestSuite _nameA interfaceA buildInfoA)
-               (TestSuite _nameB interfaceB buildInfoB) = do
+               (TestSuite _nameB interfaceB buildInfoB)
+#endif
+  = do
   checkSame "Cannot change test-suite type" interfaceA interfaceB
   checkBuildInfo componentName buildInfoA buildInfoB
+#if MIN_VERSION_Cabal(3,7,0)
+  -- @test-generators@
+  checkSame "Cannot change test-generators" testGeneratorsA testGeneratorsB
+#endif
 
 checkBenchmark :: ComponentName -> Check Benchmark
 checkBenchmark componentName

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -48,6 +48,9 @@ import qualified Distribution.Pretty                    as C
 import qualified Distribution.Verbosity                 as C
 import qualified Distribution.Version                   as C
 import qualified Distribution.Text                      as C
+#if MIN_VERSION_Cabal(3,7,0)
+import qualified Distribution.Simple.PackageDescription as C
+#endif
 
 import           Lens.Micro
 import           Lens.Micro.Mtl


### PR DESCRIPTION
Deal with new `testGenerators` field of `TestSuite` stanza in a conservative way: do not allow changes in revision. See:
- https://github.com/haskell/cabal/pull/7688#discussion_r895985969