### PR TITLE
Housekeeping: CabalRevisions.hs, mtl-2.3, CI bump

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.15.20220808
+# version: 0.15.202211107
 #
-# REGENDATA ("0.15.20220808",["github","hackage-cli.cabal"])
+# REGENDATA ("0.15.202211107",["github","hackage-cli.cabal"])
 #
 name: Haskell-CI
 on:
@@ -32,14 +32,14 @@ jobs:
     strategy:
       matrix:
         include:
-          - compiler: ghc-9.4.1
+          - compiler: ghc-9.4.3
             compilerKind: ghc
-            compilerVersion: 9.4.1
+            compilerVersion: 9.4.3
             setup-method: ghcup
             allow-failure: false
-          - compiler: ghc-9.2.4
+          - compiler: ghc-9.2.5
             compilerKind: ghc
-            compilerVersion: 9.2.4
+            compilerVersion: 9.2.5
             setup-method: ghcup
             allow-failure: false
           - compiler: ghc-9.0.2

--- a/hackage-cli.cabal
+++ b/hackage-cli.cabal
@@ -17,8 +17,8 @@ build-type:          Simple
 
 tested-with:
   -- Keep in descending order.
-  GHC == 9.4.1
-  GHC == 9.2.4
+  GHC == 9.4.3
+  GHC == 9.2.5
   GHC == 9.0.2
   GHC == 8.10.7
   GHC == 8.8.4
@@ -47,7 +47,7 @@ library cabal-revisions
     , bytestring   >= 0.10.4.0 && < 0.12
     , Cabal        >= 3.4      && < 3.10
     , containers   >= 0.5.0.0  && < 0.7
-    , mtl          >= 2.2.2    && < 2.4
+    , mtl          >= 2.2.2    && < 2.3   || >= 2.3.1 && < 2.4
     , pretty      ^>= 1.1.2
 
   exposed-modules:

--- a/lib/Distribution/Server/Util/CabalRevisions.hs
+++ b/lib/Distribution/Server/Util/CabalRevisions.hs
@@ -361,8 +361,8 @@ checkPackageDescriptions checkXRevision
             extraDocFilesA extraDocFilesB
 
   checkSame "Cannot change custom/extension fields"
-            (filter (\(f,_) -> not (f `elem` ["x-revision","x-curation"])) customFieldsPDA)
-            (filter (\(f,_) -> not (f `elem` ["x-revision","x-curation"])) customFieldsPDB)
+            (filter (\(f,_) -> f `notElem` ["x-revision","x-curation"]) customFieldsPDA)
+            (filter (\(f,_) -> f `notElem` ["x-revision","x-curation"]) customFieldsPDB)
 
   checkSpecVersionRaw pdA pdB
   checkSetupBuildInfo setupBuildInfoA setupBuildInfoB
@@ -583,15 +583,15 @@ checkSetupBuildInfo (Just _) Nothing =
 
 checkSetupBuildInfo Nothing (Just (SetupBuildInfo setupDependsA _internalA)) =
     logChange $ Change Normal
-                       ("added a 'custom-setup' section with 'setup-depends'")
+                       "added a 'custom-setup' section with 'setup-depends'"
                        "[implicit]" (intercalate ", " (map prettyShow setupDependsA))
 
 checkSetupBuildInfo (Just (SetupBuildInfo setupDependsA _internalA))
                     (Just (SetupBuildInfo setupDependsB _internalB)) = do
     forM_ removed $ \dep ->
-      logChange $ Change Normal ("removed 'custom-setup' dependency on") (prettyShow dep) ""
+      logChange $ Change Normal "removed 'custom-setup' dependency on" (prettyShow dep) ""
     forM_ added $ \dep ->
-      logChange $ Change Normal ("added 'custom-setup' dependency on") "" (prettyShow dep)
+      logChange $ Change Normal "added 'custom-setup' dependency on" "" (prettyShow dep)
     forM_ changed $ \(pkgn, (verA, verB)) ->
         changesOk ("the 'custom-setup' dependency on " ++ prettyShow'' pkgn)
                   prettyShow verA verB


### PR DESCRIPTION
- Pull cosmetic changes from hackage-server/CabalRevisions.
   Keep our copy of CabalRevisions.hs in sync with the hackage-server one.
- Exclude broken `mtl-2.3.`
- Bump CI to latest GHC minor versions