### PR TITLE
CI stack: switch to ubuntu-22.04

### DIFF
--- a/.github/workflows/stack.yml
+++ b/.github/workflows/stack.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - uses: haskell/actions/setup@v1
+    - uses: haskell/actions/setup@v2
       id: haskell-setup
       with:
         ghc-version: ${{ matrix.ghc-ver }}

--- a/.github/workflows/stack.yml
+++ b/.github/workflows/stack.yml
@@ -14,7 +14,10 @@ jobs:
       fail-fast: false
       matrix:
         os:      [ubuntu-latest]
-        ghc-ver: [9.4.3, 9.2.5, 9.0.2, 8.10.7, 8.8.4, 8.6.5, 8.4.4, 8.2.2]
+        ghc-ver: [9.4.3, 9.2.5, 9.0.2, 8.10.7]
+          # On ubuntu-22.04 the old versions 8.8.4, 8.6.5, 8.4.4, 8.2.2 fail due to HsOpenSSL linking errors.
+          # They used to work under ubuntu-20.04, but it is not work the trouble maintaining them.
+          # Apparently, HsOpenSSL-0.11.6 and older are too old for ubuntu-22.04.
         include:
           - os: macos-latest
             ghc-ver: 9.4.3

--- a/.github/workflows/stack.yml
+++ b/.github/workflows/stack.yml
@@ -53,11 +53,6 @@ jobs:
         sudo apt-get update
         sudo apt-get install libbrotli-dev -qq
 
-    - name: Install the numa library (Ubuntu, GHC 8.4.4)
-      if: ${{ runner.os == 'Linux' && matrix.ghc-ver == '8.4.4' }}
-      run: |
-        sudo apt-get install libnuma-dev -qq
-
     - name: Set environment variables based on Haskell setup
       run: |
         export STACK_VER=$(stack --numeric-version)

--- a/hackage-cli.cabal
+++ b/hackage-cli.cabal
@@ -15,6 +15,7 @@ maintainer:          Andreas Abel
 category:            Development
 build-type:          Simple
 
+-- Supported GHC versions when building with cabal:
 tested-with:
   -- Keep in descending order.
   GHC == 9.4.3
@@ -31,6 +32,12 @@ extra-source-files:
   README.md
   fixtures/*.diff
   fixtures/*.cabal
+  -- Supported GHC versions when building with stack:
+  stack-9.4.3.yaml
+  stack-9.2.5.yaml
+  stack-9.2.4.yaml
+  stack-9.0.2.yaml
+  stack-8.10.7.yaml
 
 source-repository head
   Type:     git

--- a/stack-9.0.2.yaml
+++ b/stack-9.0.2.yaml
@@ -1,4 +1,4 @@
-resolver: lts-19.19
+resolver: lts-19.33
 compiler: ghc-9.0.2
 compiler-check: match-exact
 

--- a/stack-9.2.5.yaml
+++ b/stack-9.2.5.yaml
@@ -1,3 +1,3 @@
-resolver: lts-20.1
+resolver: lts-20.4
 compiler: ghc-9.2.5
 compiler-check: match-exact

--- a/stack-9.4.3.yaml
+++ b/stack-9.4.3.yaml
@@ -1,3 +1,3 @@
-resolver: nightly-2022-11-26
+resolver: nightly-2022-12-22
 compiler: ghc-9.4.3
 compiler-check: match-exact


### PR DESCRIPTION
CI stack: 
- remove `libnuma` (only needed on `ubuntu-18.04`)
- remove GHC 8.2 - 8.8 due to `HsOpenSSL` linking errors (triggered by `ubuntu-latest` switching to `ubuntu-22.04`)