### PR TITLE
CI stack: save stack already after building dependencies

### DIFF
--- a/.github/workflows/stack.yml
+++ b/.github/workflows/stack.yml
@@ -58,16 +58,31 @@ jobs:
 
     - name: Set environment variables based on Haskell setup
       run: |
-        export STACK_VER=$(stack --numeric-version)
-        echo "STACK_VER=${STACK_VER}" >> ${GITHUB_ENV}
+        STACK_VER=$(stack --numeric-version)
+        echo "STACK_VER=${STACK_VER}" >> "${GITHUB_ENV}"
 
-    - uses: actions/cache@v3
-      name: Cache dependencies
+    - name: Cache dependencies (restore)
+      uses: actions/cache/restore@v3
       id: cache
       with:
         path: ${{ steps.haskell-setup.outputs.stack-root }}
-        # A unique cache is used for each stack.yaml.
-        key: ${{ runner.os }}-stack-${{ env.STACK_VER }}-${{ hashFiles(format('stack-{0}.yaml', matrix.ghc-ver)) }}
+        key:          ${{ runner.os }}-stack-${{ env.STACK_VER }}-ghc-${{ matrix.ghc-ver }}-${{ hashFiles(format('stack-{0}.yaml', matrix.ghc-ver)) }}
+        restore-keys: ${{ runner.os }}-stack-${{ env.STACK_VER }}-ghc-${{ matrix.ghc-ver }}-
+
+    - name: Install dependencies
+      if: ${{ !steps.cache.outputs.cache-hit }}
+      run: |
+        stack build ${{ env.ARGS }} --test --only-dependencies
+
+    - name: Cache dependencies (save)
+      uses: actions/cache/save@v3
+      env:
+        key: ${{ steps.cache.outputs.cache-primary-key }}
+      # Will fail if we already have a cache with this key.
+      if:   ${{ !(steps.cache.outputs.cache-hit && env.key == steps.cache.outputs.cache-matched-key) }}
+      with:
+        path: ${{ steps.haskell-setup.outputs.stack-root }}
+        key:  ${{ env.key }}
 
     - name: Build hackage-cli
       run: |

--- a/.github/workflows/stack.yml
+++ b/.github/workflows/stack.yml
@@ -14,9 +14,9 @@ jobs:
       fail-fast: false
       matrix:
         os:      [ubuntu-latest]
-        ghc-ver: [9.4.4, 9.2.5, 9.0.2, 8.10.7]
+        ghc-ver: [9.4.4, 9.2.6, 9.0.2, 8.10.7]
           # On ubuntu-22.04 the old versions 8.8.4, 8.6.5, 8.4.4, 8.2.2 fail due to HsOpenSSL linking errors.
-          # They used to work under ubuntu-20.04, but it is not work the trouble maintaining them.
+          # They used to work under ubuntu-20.04, but it is not worth the trouble maintaining them.
           # Apparently, HsOpenSSL-0.11.6 and older are too old for ubuntu-22.04.
         include:
           - os: macos-latest

--- a/hackage-cli.cabal
+++ b/hackage-cli.cabal
@@ -35,7 +35,7 @@ extra-source-files:
   fixtures/*.cabal
   -- Supported GHC versions when building with stack:
   stack-9.4.4.yaml
-  stack-9.2.5.yaml
+  stack-9.2.6.yaml
   stack-9.0.2.yaml
   stack-8.10.7.yaml
 

--- a/stack-9.2.6.yaml
+++ b/stack-9.2.6.yaml
@@ -1,0 +1,3 @@
+resolver: lts-20.12
+compiler: ghc-9.2.6
+compiler-check: match-exact


### PR DESCRIPTION
Tinkering with the CI: split caching into `restore` and `save`.