### PR TITLE
ci 9.6.2

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.16.1
+# version: 0.16.4
 #
-# REGENDATA ("0.16.1",["github","hackage-cli.cabal"])
+# REGENDATA ("0.16.4",["github","hackage-cli.cabal"])
 #
 name: Haskell-CI
 on:
@@ -32,9 +32,9 @@ jobs:
     strategy:
       matrix:
         include:
-          - compiler: ghc-9.6.1
+          - compiler: ghc-9.6.2
             compilerKind: ghc
-            compilerVersion: 9.6.1
+            compilerVersion: 9.6.2
             setup-method: ghcup
             allow-failure: false
           - compiler: ghc-9.4.5
@@ -42,9 +42,9 @@ jobs:
             compilerVersion: 9.4.5
             setup-method: ghcup
             allow-failure: false
-          - compiler: ghc-9.2.7
+          - compiler: ghc-9.2.8
             compilerKind: ghc
-            compilerVersion: 9.2.7
+            compilerVersion: 9.2.8
             setup-method: ghcup
             allow-failure: false
           - compiler: ghc-9.0.2

--- a/.github/workflows/stack.yml
+++ b/.github/workflows/stack.yml
@@ -14,15 +14,15 @@ jobs:
       fail-fast: false
       matrix:
         os:      [ubuntu-latest]
-        ghc-ver: [9.4.5, 9.2.7, 9.0.2, 8.10.7]
+        ghc-ver: [9.6.2, 9.4.5, 9.2.8, 9.0.2, 8.10.7]
           # On ubuntu-22.04 the old versions 8.8.4, 8.6.5, 8.4.4, 8.2.2 fail due to HsOpenSSL linking errors.
           # They used to work under ubuntu-20.04, but it is not worth the trouble maintaining them.
           # Apparently, HsOpenSSL-0.11.6 and older are too old for ubuntu-22.04.
         include:
           - os: macos-latest
-            ghc-ver: 9.4.5
+            ghc-ver: 9.6.2
           - os: windows-latest
-            ghc-ver: 9.4.5
+            ghc-ver: 9.6.2
     env:
       ARGS: "--stack-yaml=stack-${{ matrix.ghc-ver }}.yaml --no-terminal --system-ghc"
 

--- a/hackage-cli.cabal
+++ b/hackage-cli.cabal
@@ -18,9 +18,9 @@ build-type:          Simple
 -- Supported GHC versions when building with cabal:
 tested-with:
   -- Keep in descending order.
-  GHC == 9.6.1
+  GHC == 9.6.2
   GHC == 9.4.5
-  GHC == 9.2.7
+  GHC == 9.2.8
   GHC == 9.0.2
   GHC == 8.10.7
   GHC == 8.8.4
@@ -34,8 +34,9 @@ extra-source-files:
   fixtures/*.diff
   fixtures/*.cabal
   -- Supported GHC versions when building with stack:
+  stack-9.6.2.yaml
   stack-9.4.5.yaml
-  stack-9.2.7.yaml
+  stack-9.2.8.yaml
   stack-9.0.2.yaml
   stack-8.10.7.yaml
 

--- a/hackage-cli.cabal
+++ b/hackage-cli.cabal
@@ -52,7 +52,7 @@ library cabal-revisions
 
   build-depends:
     , base         >= 4.10.0.0 && < 4.19
-    , bytestring   >= 0.10.4.0 && < 0.12
+    , bytestring   >= 0.10.4.0 && < 0.13
     , Cabal        >= 3.4      && < 3.11
     , containers   >= 0.5.0.0  && < 0.7
     , mtl          >= 2.2.2    && < 2.3   || >= 2.3.1 && < 2.4

--- a/stack-9.2.8.yaml
+++ b/stack-9.2.8.yaml
@@ -1,0 +1,3 @@
+resolver: lts-20.26
+compiler: ghc-9.2.8
+compiler-check: match-exact

--- a/stack-9.4.5.yaml
+++ b/stack-9.4.5.yaml
@@ -1,3 +1,3 @@
-resolver: nightly-2023-05-23
+resolver: lts-21.1
 compiler: ghc-9.4.5
 compiler-check: match-exact

--- a/stack-9.6.2.yaml
+++ b/stack-9.6.2.yaml
@@ -1,0 +1,3 @@
+resolver: nightly-2023-07-03
+compiler: ghc-9.6.2
+compiler-check: match-exact


### PR DESCRIPTION
- Bump Haskell CI to latest GHCs: 9.6.2 9.2.8
- allow bytestring-0.12
