### PR TITLE
bump tar

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/andreasabel/haskell-ci
 #
-# version: 0.17.20231012
+# version: 0.17.20231112
 #
-# REGENDATA ("0.17.20231012",["github","hackage-cli.cabal"])
+# REGENDATA ("0.17.20231112",["github","hackage-cli.cabal"])
 #
 name: Haskell-CI
 on:
@@ -42,9 +42,9 @@ jobs:
             compilerVersion: 9.6.3
             setup-method: ghcup
             allow-failure: false
-          - compiler: ghc-9.4.7
+          - compiler: ghc-9.4.8
             compilerKind: ghc
-            compilerVersion: 9.4.7
+            compilerVersion: 9.4.8
             setup-method: ghcup
             allow-failure: false
           - compiler: ghc-9.2.8
@@ -89,11 +89,10 @@ jobs:
           apt-get update
           apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5 libnuma-dev
           mkdir -p "$HOME/.ghcup/bin"
-          curl -sL https://downloads.haskell.org/ghcup/0.1.19.5/x86_64-linux-ghcup-0.1.19.5 > "$HOME/.ghcup/bin/ghcup"
+          curl -sL https://downloads.haskell.org/ghcup/0.1.20.0/x86_64-linux-ghcup-0.1.20.0 > "$HOME/.ghcup/bin/ghcup"
           chmod a+x "$HOME/.ghcup/bin/ghcup"
-          "$HOME/.ghcup/bin/ghcup" config add-release-channel https://raw.githubusercontent.com/haskell/ghcup-metadata/master/ghcup-prereleases-0.0.7.yaml;
           "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
-          "$HOME/.ghcup/bin/ghcup" install cabal 3.10.1.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
+          "$HOME/.ghcup/bin/ghcup" install cabal 3.10.2.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
           apt-get update
           apt-get install -y libbrotli-dev
         env:
@@ -113,7 +112,7 @@ jobs:
           echo "HC=$HC" >> "$GITHUB_ENV"
           echo "HCPKG=$HCPKG" >> "$GITHUB_ENV"
           echo "HADDOCK=$HADDOCK" >> "$GITHUB_ENV"
-          echo "CABAL=$HOME/.ghcup/bin/cabal-3.10.1.0 -vnormal+nowrap" >> "$GITHUB_ENV"
+          echo "CABAL=$HOME/.ghcup/bin/cabal-3.10.2.0 -vnormal+nowrap" >> "$GITHUB_ENV"
           HCNUMVER=$(${HC} --numeric-version|perl -ne '/^(\d+)\.(\d+)\.(\d+)(\.(\d+))?$/; print(10000 * $1 + 100 * $2 + ($3 == 0 ? $5 != 1 : $3))')
           echo "HCNUMVER=$HCNUMVER" >> "$GITHUB_ENV"
           echo "ARG_TESTS=--enable-tests" >> "$GITHUB_ENV"

--- a/.github/workflows/stack.yml
+++ b/.github/workflows/stack.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         os:      [ubuntu-latest]
-        ghc-ver: [9.6.3, 9.4.7, 9.2.8, 9.0.2, 8.10.7]
+        ghc-ver: [9.6.3, 9.4.8, 9.2.8, 9.0.2, 8.10.7]
           # On ubuntu-22.04 the old versions 8.8.4, 8.6.5, 8.4.4, 8.2.2 fail due to HsOpenSSL linking errors.
           # They used to work under ubuntu-20.04, but it is not worth the trouble maintaining them.
           # Apparently, HsOpenSSL-0.11.6 and older are too old for ubuntu-22.04.

--- a/hackage-cli.cabal
+++ b/hackage-cli.cabal
@@ -115,7 +115,7 @@ executable hackage-cli
         -- aeson-1.2.4.0 for stack-8.2.2.yaml
     , deepseq               ^>= 1.4.0.0 || ^>= 1.5.0.0
     , directory             ^>= 1.2.0.1 || ^>= 1.3.0.0
-    , filepath              ^>= 1.4.0.0
+    , filepath               >= 1.4.0.0  && < 2
     , http-io-streams       ^>= 0.1.0.0
     , io-streams            ^>= 1.5.0.1
     , microlens              >= 0.4.8.3  && < 4.13
@@ -127,7 +127,7 @@ executable hackage-cli
     , semigroups             >= 0.18.3   && < 0.21
     , stringsearch          ^>= 0.3.6
     , tagsoup               ^>= 0.14
-    , tar                   ^>= 0.5
+    , tar                    >= 0.5      && < 1
     , text                   >= 1.2      && < 2.2
     , time                   >= 1.5.0.1  && < 1.13
     , unordered-containers  ^>= 0.2.7

--- a/hackage-cli.cabal
+++ b/hackage-cli.cabal
@@ -29,9 +29,11 @@ tested-with:
   GHC == 8.4.4
   GHC == 8.2.2
 
-extra-source-files:
+extra-doc-files:
   CHANGELOG.md
   README.md
+
+extra-source-files:
   fixtures/*.diff
   fixtures/*.cabal
   -- Supported GHC versions when building with stack:

--- a/hackage-cli.cabal
+++ b/hackage-cli.cabal
@@ -20,7 +20,7 @@ tested-with:
   -- Keep in descending order.
   GHC == 9.8.1
   GHC == 9.6.3
-  GHC == 9.4.7
+  GHC == 9.4.8
   GHC == 9.2.8
   GHC == 9.0.2
   GHC == 8.10.7
@@ -36,7 +36,7 @@ extra-source-files:
   fixtures/*.cabal
   -- Supported GHC versions when building with stack:
   stack-9.6.3.yaml
-  stack-9.4.7.yaml
+  stack-9.4.8.yaml
   stack-9.2.8.yaml
   stack-9.0.2.yaml
   stack-8.10.7.yaml

--- a/stack-9.4.8.yaml
+++ b/stack-9.4.8.yaml
@@ -1,0 +1,3 @@
+resolver: lts-21.24
+compiler: ghc-9.4.8
+compiler-check: match-exact

--- a/stack-9.6.3.yaml
+++ b/stack-9.6.3.yaml
@@ -1,3 +1,3 @@
-resolver: nightly-2023-10-04
+resolver: nightly-2023-12-14
 compiler: ghc-9.6.3
 compiler-check: match-exact


### PR DESCRIPTION
- CI: Bump GHC 9.4 to 9.4.8
- Bump tar and filepath upper bounds
- Cabal: use extra-doc-files section
